### PR TITLE
fix(scan): add macOS WeChat V4.1.7+ applet path for Arm architecture

### DIFF
--- a/src/bin/wedecode/enum.ts
+++ b/src/bin/wedecode/enum.ts
@@ -7,6 +7,8 @@ const macGlob: string[] = [
   '/Users/*/Library/Containers/*/Data/.wxapplet/packages',
   // 版本4.0+
   '/Users/*/Library/Containers/*/Data/Documents/app_data/radium/Applet/packages',
+  // 版本4.1.7+ (Arm架构)
+  '/Users/*/Library/Containers/*/Data/Documents/app_data/radium/users/*/applet/packages',
 ];
 
 const winGlob: string[] = [


### PR DESCRIPTION
## 问题描述

修复 Issue #64 报告的 macOS Arm 架构微信版本 V4.1.7.31 小程序路径变更问题。

## 变更内容

在 `src/bin/wedecode/enum.ts` 的 `macGlob` 数组中添加新的小程序包路径：

```typescript
// 版本4.1.7+ (Arm架构)
'/Users/*/Library/Containers/*/Data/Documents/app_data/radium/users/*/applet/packages',
```

## 路径变化说明

- **旧路径**: `/Users/*/Library/Containers/*/Data/Documents/app_data/radium/Applet/packages`
- **新路径**: `/Users/*/Library/Containers/*/Data/Documents/app_data/radium/users/*/applet/packages`

主要变化：
1. 新增 `users/用户ID` 层级
2. `Applet` 改为小写 `applet`

## 测试验证

已在 macOS Arm 架构 + 微信 V4.1.7.31 环境下验证：
- ✅ glob 模式能正确匹配新路径
- ✅ 扫描功能能找到新路径下的小程序包

Closes #64