### PR TITLE
fix: UI拖放加密wxapkg时支持手动输入wxid进行解密

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -27,6 +27,7 @@ class WedecodeApp {
         this.clearLogBtn = document.getElementById('clearLogBtn');
         
         // 配置选项元素
+        this.wxidInput = document.getElementById('wxidInput');
         this.usePx = document.getElementById('usePx');
         this.unpackOnly = document.getElementById('unpackOnly');
         
@@ -327,10 +328,12 @@ class WedecodeApp {
 
     getDecompileOptions() {
         // 返回对象格式，匹配后端期望的格式
+        const wxidValue = this.wxidInput ? this.wxidInput.value.trim() : '';
         const options = {
             clear: true, // 固定设置：清空旧产物为 true
             px: this.usePx.checked,
-            unpackOnly: this.unpackOnly.checked
+            unpackOnly: this.unpackOnly.checked,
+            wxid: wxidValue || null
         };
         
         // 控制台打印配置参数
@@ -339,6 +342,7 @@ class WedecodeApp {
         console.log('  - 清空旧产物 (clear):', options.clear);
         console.log('  - 使用px单位 (px):', options.px);
         console.log('  - 仅解包模式 (unpackOnly):', options.unpackOnly);
+        console.log('  - WXID:', options.wxid || '(未设置)');
         
         return options;
     }

--- a/public/index.html
+++ b/public/index.html
@@ -493,7 +493,7 @@
                     <i class="fas fa-cog"></i> 反编译配置
                 </div>
 
-                <!-- <div class="config-group">
+                <div class="config-group">
                     <label class="config-label" for="wxidInput">微信小程序 WXID</label>
                     <div style="display: flex; align-items: center; gap: 10px;">
                         <input type="text" id="wxidInput" class="config-input" placeholder="输入小程序的 WXID (可选)" style="flex: 1;">
@@ -502,7 +502,7 @@
                             <label for="skipWxid">不使用 WXID</label>
                         </div>
                     </div>
-                </div> -->
+                </div>
 
                 <div class="config-group">
                     <div class="config-checkbox" style="margin-bottom: 10px;">

--- a/src/decompilation-controller.ts
+++ b/src/decompilation-controller.ts
@@ -49,7 +49,7 @@ class DecompilationController {
    * 单包反编译
    * */
   private async singlePackMode(wxapkgPath: string, outputPath: string): Promise<void> {
-    const packInfo = await UnpackWxapkg.unpackWxapkg(wxapkgPath, outputPath)
+    const packInfo = await UnpackWxapkg.unpackWxapkg(wxapkgPath, outputPath, this.config.wxid)
     
     // 保存第一个包的信息，用于后续获取小程序信息
     if (!this.firstPackInfo) {

--- a/src/interface/unpack-wxapkg.ts
+++ b/src/interface/unpack-wxapkg.ts
@@ -73,12 +73,12 @@ export class UnpackWxapkg {
    * 解析并保存该包中的所有文件
    * 返回获取该包各种信息 和 路径的操作对象
    * */
-  public static async unpackWxapkg(inputPath: string, outputPath: string): Promise<UnPackInfo> {
+  public static async unpackWxapkg(inputPath: string, outputPath: string, externalWxid?: string | null): Promise<UnPackInfo> {
     let __APP_BUF__ = fs.readFileSync(inputPath)
 
     // 检测是否需要解密
     if (needsDecryption(__APP_BUF__)) {
-      const wxid = UnpackWxapkg.extractWxid(inputPath);
+      const wxid = externalWxid || UnpackWxapkg.extractWxid(inputPath);
       if (wxid) {
         printLog(`\n \u25B6 检测到加密包，正在解密... (wxid: ${colors.blue(wxid)})`, {isStart: true});
         __APP_BUF__ = decryptWxapkg(wxid, __APP_BUF__);


### PR DESCRIPTION
## 关联 Issue

Fixes https://github.com/biggerstar/wedecode/issues/59

## 问题描述

通过 UI 界面拖放加密的 wxapkg 文件时，文件被 multer 保存到 `<workspace>/uploads/__APP__.wxapkg`，原始路径中的 wxid 信息丢失，导致 [extractWxid](cci:1://file:///d:/nodejs_code/wedecode/src/interface/unpack-wxapkg.ts:57:2-69:3) 无法从新路径中提取 appid 而报错。命令行模式因保留了原始完整路径所以正常工作。

## 修复方案

- [unpackWxapkg](https://github.com/biggerstar/wedecode/blob/main/src/interface/unpack-wxapkg.ts) 新增 `externalWxid` 可选参数，优先使用外部传入的 wxid
- [singlePackMode](https://github.com/biggerstar/wedecode/blob/main/src/decompilation-controller.ts) 将 `config.wxid` 传递给 [unpackWxapkg](cci:1://file:///d:/nodejs_code/wedecode/src/interface/unpack-wxapkg.ts:71:2-134:3)
- 前端 [index.html](https://github.com/biggerstar/wedecode/blob/main/public/index.html) 启用 wxid 输入框，用户可手动填写 appid 用于解密加密包
- [getDecompileOptions](https://github.com/biggerstar/wedecode/blob/main/public/app.js) 读取 wxid 值并通过已有的传递链路送达解密层

## 影响范围

仅影响加密包的 UI 拖放场景，命令行行为不变。