### PR TITLE
bug: fix issues #72

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -265,7 +265,7 @@ export function getParameterNames(fn: Function) {
  * 判断是否是wx 的 appid
  * */
 export function isWxAppid(str: string) {
-  const reg = /^wx[0-9a-f]{16}$/i
+  const reg = /^wx[0-9a-f]{14,16}$/i 
   str = str.trim()
-  return str.length === 18 && reg.test(str)
+  return str.length >= 16 && str.length <= 18 && reg.test(str)
 }


### PR DESCRIPTION
修复 #72 问题，简单改了正在匹配规则，自己编译了下可以反编译了
>正则从 {16} 改为 {14,16}，允许 14-16 位十六进制字符
长度检查从固定 18 改为范围 16-18