### PR TITLE
Fix typo in comment: 'unkown-arrayStart' → 'unknown-arrayStart'

### DIFF
--- a/src/utils/get-z.ts
+++ b/src/utils/get-z.ts
@@ -164,7 +164,7 @@ function restoreSingle(ops: any, withScope = false) {
           }
           break;
         }
-      case 4: // unkown-arrayStart? 将操作符下 数组 拼接数组成字符串形式
+      case 4: // unknown-arrayStart? 将操作符下 数组 拼接数组成字符串形式
         ans = restoreNext(ops[1], true);
         break;
       case 5: // merge-array


### PR DESCRIPTION
Fix typo in comment: 'unkown-arrayStart' → 'unknown-arrayStart' in src/utils/get-z.ts

Note: Other 'unkown' occurrences in string literals (\_\_unkownMerge, \_\_unkownSpecific) were intentionally kept as they appear to be internal protocol/encoding keys.